### PR TITLE
ndims for AbstractLattice and AbstractSite

### DIFF
--- a/src/abstract_lattice.jl
+++ b/src/abstract_lattice.jl
@@ -88,6 +88,11 @@ Bravais lattice vectors with `Int64` site labels and `Symbol` bond labels.
 AbstractLattice
 
 
+"""
+Number of spatial dimensions the lattice is embedded in.
+"""
+Base.ndims(l::AbstractLattice{S}) where S<:AbstractSite = ndims(S)
+
 
 ################################################################################
 #

--- a/src/abstract_site.jl
+++ b/src/abstract_site.jl
@@ -57,6 +57,12 @@ true
 AbstractSite
 
 
+"""
+Number of spatial dimensions the site is embedded in.
+"""
+Base.ndims(::Type{S}) where {N,S<:AbstractSite{L,D} where L} = D
+
+
 
 ################################################################################
 #


### PR DESCRIPTION
Extending `Base.ndims` for above mentioned types.